### PR TITLE
Removing WP v check

### DIFF
--- a/elementor.php
+++ b/elementor.php
@@ -48,8 +48,6 @@ add_action( 'plugins_loaded', 'elementor_load_plugin_textdomain' );
 
 if ( ! version_compare( PHP_VERSION, '5.4', '>=' ) ) {
 	add_action( 'admin_notices', 'elementor_fail_php_version' );
-} elseif ( ! version_compare( get_bloginfo( 'version' ), '4.7', '>=' ) ) {
-	add_action( 'admin_notices', 'elementor_fail_wp_version' );
 } else {
 	require ELEMENTOR_PATH . 'includes/plugin.php';
 }
@@ -57,7 +55,7 @@ if ( ! version_compare( PHP_VERSION, '5.4', '>=' ) ) {
 /**
  * Load Classic Elements textdomain.
  *
- * Load gettext translate for Elementor text domain.
+ * Load gettext translate for Classic Elements text domain.
  *
  * @since 1.0.0
  *
@@ -79,22 +77,6 @@ function elementor_load_plugin_textdomain() {
 function elementor_fail_php_version() {
 	/* translators: %s: PHP version */
 	$message = sprintf( esc_html__( 'Classic Elements requires PHP version %s+, plugin is currently NOT RUNNING.', 'elementor' ), '5.4' );
-	$html_message = sprintf( '<div class="error">%s</div>', wpautop( $message ) );
-	echo wp_kses_post( $html_message );
-}
-
-/**
- * Classic Elements admin notice for minimum WordPress version.
- *
- * Warning when the site doesn't have the minimum required WordPress version.
- *
- * @since 1.5.0
- *
- * @return void
- */
-function elementor_fail_wp_version() {
-	/* translators: %s: WordPress version */
-	$message = sprintf( esc_html__( 'Classic Elements requires WordPress version %s+. Because you are using an earlier version, the plugin is currently NOT RUNNING.', 'elementor' ), '4.7' );
 	$html_message = sprintf( '<div class="error">%s</div>', wpautop( $message ) );
 	echo wp_kses_post( $html_message );
 }


### PR DESCRIPTION
Removing the strict WP version check as the plugin is being refactored strictly for ClassicPress

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Remove WP version check

## Description
An explanation of what is done in this PR

* Removed the WP version check upon activation.

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)

Fixes #2 
