### PR TITLE
Fix - Tag value can be '0'

### DIFF
--- a/core/dynamic-tags/tag.php
+++ b/core/dynamic-tags/tag.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elementor\Core\DynamicTags;
 
+use Elementor\Utils;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
@@ -34,7 +36,7 @@ abstract class Tag extends Base_Tag {
 
 		$value = ob_get_clean();
 
-		if ( $value ) {
+		if ( ! Utils::is_empty( $value ) ) {
 			// TODO: fix spaces in `before`/`after` if WRAPPED_TAG ( conflicted with .elementor-tag { display: inline-flex; } );
 			if ( ! empty( $settings['before'] ) ) {
 				$value = wp_kses_post( $settings['before'] ) . $value;


### PR DESCRIPTION
Applying the hotfix from upstream where the Tag $value can be '0'

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x" with no spaces eg: [x]. -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Summary

This PR can be summarized in the following changelog entry:

* Fix: Tag, $value can be '0'

## Description
An explanation of what is done in this PR

* Added a check on the $value to make sure it's not empty before returning it

## Test instructions
This PR can be tested by following these steps:

*

## Quality assurance

- [x] I have tested this code to the best of my abilities
- [ ] I have added unittests to verify the code works as intended
- [ ] Docs have been added / updated (for bug fixes / features)
